### PR TITLE
Prevent calling `set_variations` on creating instance's field, causing extra DB queries in some scenarios

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -312,7 +312,7 @@ class StdImageField(ImageField):
     def contribute_to_class(self, cls, name):
         """Generate all operations on specified signals."""
         super().contribute_to_class(cls, name)
-        signals.post_init.connect(self.set_variations, sender=cls)
+        # signals.post_init.connect(self.set_variations, sender=cls)
 
     def validate(self, value, model_instance):
         super().validate(value, model_instance)


### PR DESCRIPTION
With this signal on Model's instance creation it executes `set_variations` which caused creation of useless DB queries, to receive field's value, in case model doesn't have one.

If:
`User.logo = StdImageField(variations={'thumbnail': (300, 300, True)})`

Calling this:
```
u = User.objects.only('id').get(id=1)
# would execute two queries, loading logo in the second one
```

After removing this signal, only if there's actual actions are done with the field it will cause an extra request:
```
u = User.objects.only('id').get(id=1)
u.logo
# or
u.logo.thumbnail
# `set_variations` was called in `StdImageFileDescriptor` and all the needed data is available
```